### PR TITLE
WormNAT2Ex fixes

### DIFF
--- a/WormNAT2/wkWormNAT2.dpr
+++ b/WormNAT2/wkWormNAT2.dpr
@@ -375,6 +375,7 @@ var
   wsaData: TWSAData;
   ProcessHandle, Event: THandle;
 begin
+  Arr:=nil;
   for I:=1 to ParamCount-1 do
     if ParamStr(I)='/wnat2' then
     begin


### PR DESCRIPTION
Fixes:
- WormNAT2Ex initialization was getting stuck in a loop waiting for a thread that cannot start due to the DLL not yet having returned from DllMain. Windows doesn't let threads in a DLL execute until the process-attach DllMain returns. Fixed by not using the wait there at all, only normal WormNAT2 needed it.
- Fixed retrieval of the local port the game is hosted on. This was likely missed when porting the original WormNAT2Ex.
- Don't require winsock 2.2: it's not needed here, using 1.1 instead.
- Break after successfully parsing a correct /wnat2 commandline, preventing it from potentially getting another one later in the command-line.
- Changed PROCESS_ALL_ACCESS to PROCESS_DUP_HANDLE in OpenProcess: we don't need anything else. Also handle errors with OpenProcess and display GetLastError's.
- Fixed the warning "variable might be uninitialized" during compilation.
